### PR TITLE
Add zeek/zeek-version.h include

### DIFF
--- a/src/S7COMM.h
+++ b/src/S7COMM.h
@@ -2,6 +2,12 @@
 
 #pragma once
 
+#if __has_include(<zeek/zeek-version.h>)
+#include <zeek/zeek-version.h>
+#else
+#include <zeek/zeek-config.h>
+#endif
+
 #include <zeek/analyzer/protocol/tcp/TCP.h>
 
 #include "s7comm_pac.h"


### PR DESCRIPTION
Due to zeek/zeek#2806 with the latest master version this requires an explicit `zeek/zeek-version.h` include. That include is good practice anyway.

Reference zeek/zeek#2847.

Originally suggested by @awelzel in cisagov/icsnpp-bacnet#19.