### PR TITLE
Set cmake_minimum_required to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 project(Plugin)
 


### PR DESCRIPTION
[Zeek v6.1.0](https://github.com/zeek/zeek/releases/tag/v6.1.0) requires that external plugins have the minimum CMake version to be set to 3.15.

This change slightly tweaks the CMakeLists.txt file to have:

```
cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
```